### PR TITLE
update for rust 1.2 stable

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
       <tr>
         <th>String</th>
         <td class="na">n/a</td>
-        <td>x.as_slice()</td>
+        <td>&*x</td>
       </tr>
       <tr>
         <th>&amp;str</th>
@@ -127,7 +127,7 @@
       <tr>
         <th>Vec&lt;T></th>
         <td class="na">n/a</td>
-        <td>x.as_slice()</td>
+        <td>&x[..]</td>
         <td>x.into_boxed_slice()</td>
       </tr>
       <tr>

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#![feature(core)]
-#![feature(collections)]
-
 // This should fail to compile if any of these code examples are wrong.
 
 #[allow(dead_code)]
@@ -14,7 +11,7 @@ fn main() {
     let st: String = s.to_string();
 
     // String => &str
-    let str: &str = st.as_slice();
+    let str: &str = &st;
 }
 
 // i32 ---------------------------------------------------------------
@@ -189,7 +186,7 @@ fn test_parse_option_handling_expect_some() {
 }
 
 #[test]
-#[should_fail(expected = "Parsing int from string failed")]
+#[should_panic(expected = "Parsing int from string failed")]
 #[allow(unused_variables)]
 fn test_parse_option_handling_expect_none() {
     let x: i32 = None.expect("Parsing int from string failed");
@@ -202,7 +199,7 @@ fn test_parse_option_handling_unwrap_some() {
 }
 
 #[test]
-#[should_fail(expected = "called `Option::unwrap()` on a `None` value")]
+#[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
 #[allow(unused_variables)]
 fn test_parse_option_handling_unwrap_none() {
     let x: i32 = None.unwrap();
@@ -214,7 +211,7 @@ fn test_parse_option_handling_unwrap_none() {
 fn test_vec_to_slice_happy() {
     let x = vec!(1u8, 2u8, 3u8);
     static Y: &'static [u8] = &[1, 2, 3];
-    assert_eq!(Y, x.as_slice());
+    assert_eq!(Y, &x[..]);
 }
 
 #[test]


### PR DESCRIPTION
Updated the example for conversion from String to &str and from Vector to slice to work with the rust 1.2 stable channel. Also updated the #[should_fail] macro to the should_panic as mentioned in the rust guide. 
