### PR TITLE
i32.to_string() does not work

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         <th>i32</th>
         <td class="na">n/a</td>
         <td>x as u32</td>
-        <td>x.to_string()</td>
+        <td>(x as u32).to_string()</td>
         <td>x as f64</td>
       </tr>
       <tr>


### PR DESCRIPTION
I tried to use yyyy.to_String(), where yyyy is i32 but i go the following error message, am using rustup 1.18.3 (435397f48 2019-05-22)
no method named `to_String` found for type `i32` in the current scope